### PR TITLE
Fixed sign in compositeArea calc (polygons with holes now calc OK)

### DIFF
--- a/lib/+Depomod/+Layout/Site.m
+++ b/lib/+Depomod/+Layout/Site.m
@@ -171,9 +171,9 @@ classdef Site < dynamicprops
                 a = polyarea(x(1:(idx(1)-1)), y(1:(idx(1)-1)));
                 for pidx = 1:numel(idx)
                     if pidx == numel(idx)
-                        a = a + polyarea(x((idx(pidx)+1):end), y((idx(pidx)+1):end));
+                        a = a - polyarea(x((idx(pidx)+1):end), y((idx(pidx)+1):end));
                     else
-                        a = a + polyarea(x((idx(pidx)+1):(idx(pidx+1)-1)), y((idx(pidx)+1):(idx(pidx+1)-1)));
+                        a = a - polyarea(x((idx(pidx)+1):(idx(pidx+1)-1)), y((idx(pidx)+1):(idx(pidx+1)-1)));
                     end
                 end
             else

--- a/lib/+Depomod/+Layout/Site.m
+++ b/lib/+Depomod/+Layout/Site.m
@@ -125,14 +125,22 @@ classdef Site < dynamicprops
                 end
             end
             
-            [x, y] = polybool('union', cageStruct(1).x, cageStruct(1).y, cageStruct(1).x, cageStruct(1).y);
+            %[x, y] = polybool('union', cageStruct(1).x, cageStruct(1).y, cageStruct(1).x, cageStruct(1).y);
+            A = polyshape(cageStruct(1).x,cageStruct(1).y,'Simplify',false); 
+            [x,y] = boundary(A);
+
             
             for ss = 2:length(cages)                
                 x1 = x;
                 y1 = y;
                 x2 = cageStruct(ss).x;
                 y2 = cageStruct(ss).y;
-                [x, y] = polybool('union', x1, y1, x2, y2);
+                %[x, y] = polybool('union', x1, y1, x2, y2);
+                B = polyshape(x1,y1,'Simplify',false); 
+                C = polyshape(x2,y2,'Simplify',false); 
+                D = union(B,C);
+                [x,y] = boundary(D);
+
             end
             if plotPerimeter
                 figure;

--- a/lib/+Depomod/+Run/Base.m
+++ b/lib/+Depomod/+Run/Base.m
@@ -232,11 +232,26 @@ classdef (Abstract) Base < handle
                     % Here we generate x,y vectors covering extent of domain with size matching
                     % sur.Z value. This seems to fix things.
                     % Andy used double for loop to populate E,N. But can do it by manipulating meshgrid.
-                    dom=R.project.bathymetry.Domain.spatial;
-                    minX=str2double(dom.minX);
-                    minY=str2double(dom.minY);
-                    maxX=str2double(dom.maxX);
-                    maxY=str2double(dom.maxY);
+                    try
+                        dom=R.project.bathymetry.Domain.spatial;
+                        minX=str2double(dom.minX);
+                        minY=str2double(dom.minY);
+                        maxX=str2double(dom.maxX);
+                        maxY=str2double(dom.maxY);
+                    catch
+%                     dom=R.project.bathymetry.Domain.spatial;
+                        try
+                            minX=str2double(min(R.project.bathymetry.NodeX));
+                            minY=str2double(min(R.project.bathymetry.NodeY));
+                            maxX=str2double(max(R.project.bathymetry.NodeX));
+                            maxY=str2double(max(R.project.bathymetry.NodeY));
+                        catch
+                            print('Cannot define model extent')
+                        end
+                    end
+                    set(gca,'Xlim',[minX,maxX])
+                    set(gca,'Ylim',[minY,maxY])
+
                     Nx=length(sur.X)+1;
                     Ny=length(sur.Y)+1;
                     X=linspace(minX,maxX,Nx);
@@ -298,9 +313,9 @@ classdef (Abstract) Base < handle
                 
                 if ~isempty(legendContours)
                     if str2num(mv(1:4)) < 2017
-                        leg = legend(legendContours,legendlabels);
+                        leg = legend(legendContours,legendlabels,'color','w');
                     else
-                        [~,leg] = legend(legendContours,legendlabels, 'AutoUpdate', 'off');
+                        [~,leg] = legend(legendContours,legendlabels, 'AutoUpdate', 'off','color','w');
                     end
                     
                     PatchInLegend = findobj(leg, 'type', 'patch');
@@ -405,6 +420,8 @@ classdef (Abstract) Base < handle
                     end
                 end
                 
+                set(gca,'Xlim',[min(R.project.bathymetry.NodeX),max(R.project.bathymetry.NodeX)])
+                set(gca,'Ylim',[min(R.project.bathymetry.NodeY),max(R.project.bathymetry.NodeY)])
                 set(gca,'layer','top');
                 
             end

--- a/lib/+Depomod/Project.m
+++ b/lib/+Depomod/Project.m
@@ -1,11 +1,11 @@
 classdef (Abstract) Project < dynamicprops
     
     properties
-        name@char;
-        path@char;
-        solidsRuns@Depomod.Run.Collection;
-        EmBZRuns@Depomod.Run.Collection;
-        TFBZRuns@Depomod.Run.Collection;
+        name char;
+        path char;
+        solidsRuns Depomod.Run.Collection;
+        EmBZRuns Depomod.Run.Collection;
+        TFBZRuns Depomod.Run.Collection;
     end
     
      methods (Static = true)

--- a/lib/+NewDepomod/+Run/Base.m
+++ b/lib/+NewDepomod/+Run/Base.m
@@ -672,6 +672,7 @@ classdef Base < Depomod.Run.Base
             
             jv = NewDepomod.Java;
 
+			runCommand = '"C:\Program Files\depomodruntimecontainer\bin\depomodruntimecontainer"'
             commandStringOnly = 0;
             singleRunOnly = 1;
             showConsoleOutput = 1;
@@ -680,20 +681,23 @@ classdef Base < Depomod.Run.Base
 
             for i = 1:2:length(varargin)
               switch varargin{i}
-                case 'commandStringOnly'
-                  commandStringOnly = varargin{i+1};
+				case 'runCommand'
+					runCommand = varargin{i+1}
+				case 'commandStringOnly'
+					commandStringOnly = varargin{i+1};
                 case 'singleRunOnly'
-                  singleRunOnly = varargin{i+1};
+					singleRunOnly = varargin{i+1};
                 case 'showConsoleOutput'
-                  showConsoleOutput = varargin{i+1};
+					showConsoleOutput = varargin{i+1};
                 case 'noSplash'
-                  noSplash = varargin{i+1};
+					noSplash = varargin{i+1};
                 case 'runInBackground'
-                  runInBackground = varargin{i+1};
+					runInBackground = varargin{i+1};
               end
             end
 
             cmd = jv.run(...
+				'runCommand', runCommand, ...
                 'singleRunOnly', singleRunOnly, ...
                 'commandStringOnly', commandStringOnly, ...
                 'modelRunTimeFile',    R.runtimePath, ...

--- a/lib/+NewDepomod/+Run/Base.m
+++ b/lib/+NewDepomod/+Run/Base.m
@@ -124,16 +124,16 @@ classdef Base < Depomod.Run.Base
     end
     
     properties
-        modelFile@NewDepomod.PropertiesFile;
-        physicalPropertiesFile@NewDepomod.PropertiesFile;
-        configurationFile@NewDepomod.PropertiesFile;
-        runtimeFile@NewDepomod.PropertiesFile;
-        inputsFile@NewDepomod.InputsPropertiesFile;
-        iterationInputsFile@NewDepomod.InputsPropertiesFile;
-        exportedTimeSeriesFile@NewDepomod.TimeSeriesFile;
-        consolidatedTimeSeriesFile@NewDepomod.TimeSeriesFile;
-        solidsSur@Depomod.Sur.Solids;
-        carbonSur@Depomod.Sur.Solids;
+        modelFile NewDepomod.PropertiesFile;
+        physicalPropertiesFile NewDepomod.PropertiesFile;
+        configurationFile NewDepomod.PropertiesFile;
+        runtimeFile NewDepomod.PropertiesFile;
+        inputsFile NewDepomod.InputsPropertiesFile;
+        iterationInputsFile NewDepomod.InputsPropertiesFile;
+        exportedTimeSeriesFile NewDepomod.TimeSeriesFile;
+        consolidatedTimeSeriesFile NewDepomod.TimeSeriesFile;
+        solidsSur Depomod.Sur.Solids;
+        carbonSur Depomod.Sur.Solids;
         label; % generalisation of run number
         iterationRunNumber = [];
         modelFileName = '';

--- a/lib/+NewDepomod/BathymetryMikeMesh.m
+++ b/lib/+NewDepomod/BathymetryMikeMesh.m
@@ -154,12 +154,17 @@ classdef BathymetryMikeMesh < handle
         
         function h = plot(BMM, varargin)
             mesh = 0;
-            
+            % TPA 08/05/2023
+            numCElems = 0;
+
             if ~isempty(varargin)
                 for i = 1:2:size(varargin,2) % only bother with odd arguments, i.e. the labels
                     switch varargin{i}
-                      case 'mesh'
-                        mesh = varargin{i + 1};
+                        case 'mesh'
+                            mesh = varargin{i + 1};
+                        % TPA 08/05/2023
+                        case 'contour'
+                            numCElems = varargin{i + 1};
                     end
                 end   
             end
@@ -171,8 +176,13 @@ classdef BathymetryMikeMesh < handle
             
             minDepth = max(BMM.NodeZ);
             maxDepth = min(BMM.NodeZ);
-            numCElems = ceil(minDepth) - floor(maxDepth);
-            
+            % TPA 08/05/2023: Encase in "if" to allow effective plotting of a contour by
+            % supplying number of levels as 'bathyContour' argument to main
+            % plot function
+            if numCElems == 0 || numCElems == 1
+                numCElems = ceil(minDepth) - floor(maxDepth);
+            end
+ 
             cmap = colormap(flipud(bone(numCElems)));
             
             bathyColour = zeros(numel(BMM.NodeZ),3);
@@ -189,8 +199,8 @@ classdef BathymetryMikeMesh < handle
                 end
                 
             end
-                        
-            bathyHandle=trisurf(tri,x,y,z,'FaceVertexCData',bathyColour,'FaceColor', 'interp','EdgeColor','none','FaceAlpha',0.7);
+
+            bathyHandle=trisurf(tri,x,y,z,'FaceVertexCData',bathyColour,'FaceColor', 'interp','EdgeColor','none','FaceAlpha',1);
             hold on;
             view(2);
             
@@ -221,6 +231,11 @@ classdef BathymetryMikeMesh < handle
                 xtickformat('%8.f');
                 ytickformat('%8.f');
             end
+            
+            % TPA 08/05/2023: Note that the above attempt to colour the land green does
+            % nothing for an irregular mesh. The line below works, at the
+            % expense of putting extra green around the water boundary too
+            set(gca,'Color',[0 0.3 0])
         end
         
         function boolMatrix = shallowSeabedIndexes(B, depth)

--- a/lib/+NewDepomod/InputsPropertiesFile.m
+++ b/lib/+NewDepomod/InputsPropertiesFile.m
@@ -34,7 +34,8 @@ classdef InputsPropertiesFile < NewDepomod.DataPropertiesFile
             IPF.FeedInputs.stockingDensity = num2str(biomass * 1000.0 / IPF.run.cages.cageVolume);
             
             feedWaterPercentage = 9;
-            feedWastePercentage = 3;
+            %feedWastePercentage = 3;
+            feedWastePercentage = 1;
             feedAbsorbedPercentage = 85;
             feedCarbonPercentage   = 49;
             faecesCarbonPercentage = 30;

--- a/lib/+NewDepomod/Java.m
+++ b/lib/+NewDepomod/Java.m
@@ -3,9 +3,12 @@ classdef Java
     properties (Constant = true)
         versionName    = 'newDEPOMOD'
         versionNo      = 2;
-        runCommand     = '"C:\Program Files\depomodruntimecontainer\bin\depomodruntimecontainer"';
+        % runCommand     = '"C:\Program Files\depomodruntimecontainer\bin\depomodruntimecontainer"';
         exportCommand  = 'newDEPOMOD\scripts\RunExporter.bat';
     end
+	properties
+		runCommand     = '"C:\Program Files\depomodruntimecontainer\bin\depomodruntimecontainer"';
+	end
     
     methods (Static = true)
         function [newProject, oldProject] = export(run, newProjectPath, varargin)
@@ -101,13 +104,15 @@ classdef Java
         end
                 
         function command = run(J, varargin)
-            command = J.runCommandStringWithOptions(varargin{:});
+            
             commandStringOnly = 0;
             runInBackground   = 1;
             verbose           = 1;
             
             for i = 1:2:length(varargin) % only bother with odd arguments, i.e. the labels
               switch varargin{i}
+				case 'runCommand'
+					J.runCommand = varargin{i+1};
                 case 'commandStringOnly'
                   commandStringOnly = varargin{i+1};
                 case 'runInBackground'
@@ -116,6 +121,8 @@ classdef Java
                   verbose = varargin{i+1};
               end
             end
+			
+			command = J.runCommandStringWithOptions(varargin{:});
             
             if ~commandStringOnly 
                 if verbose

--- a/lib/+NewDepomod/Project.m
+++ b/lib/+NewDepomod/Project.m
@@ -73,9 +73,9 @@ classdef Project < Depomod.Project
     end
     
     properties
-        location@NewDepomod.PropertiesFile;
-        bathymetry% @NewDepomod.BathymetryFile
-        flowmetry@NewDepomod.FlowmetryFile
+        location NewDepomod.PropertiesFile;
+        bathymetry% NewDepomod.BathymetryFile
+        flowmetry NewDepomod.FlowmetryFile
     end
     
     methods

--- a/lib/findRuns.m
+++ b/lib/findRuns.m
@@ -1,0 +1,20 @@
+function Runs=findRuns(project)
+
+	Runs=table;
+	for i=1:length(project.solidsRuns.labels)
+		Runs.runType(i)={'NONE'};
+		Runs.Number(i)=project.solidsRuns.numbers(i);
+		Runs.Label(i)=project.solidsRuns.labels(i);
+	end
+	for j=1:length(project.EmBZRuns.labels)
+		Runs.runType(i+j)={'EmBZ'};
+		Runs.Number(i+j)=project.EmBZRuns.numbers(j);
+		Runs.Label(i+j)=project.EmBZRuns.labels(j);
+	end
+	for k=1:length(project.TFBZRuns.labels)
+		Runs.runType(i+j+k)={'TFBZ'};
+		Runs.Number(i+j+k)=project.TFBZRuns.numbers(k);
+		Runs.Label(i+j+k)=project.TFBZRuns.labels(k);
+	end
+	Runs=sortrows(Runs);
+end


### PR DESCRIPTION
Calculation of Allowable Mixing Zone area (+Depomod/+Layout/Site.m) was incorrect. Pen layouts with large spacing can have "holes" within the overall area. The "compositeArea" function attempted to deal with this scenario but added the areas of the holes to (rather than subtracted them from) the area of the external polygon. 

The code makes use of Matlab's "polyarea" function which gives the same result regardless of whether polygon nodes are specified clockwise or anticlockwise.

With the suggested change the mixing zone area should be correct and match with that given by Depomod itself.